### PR TITLE
fix easyrsa renew command check

### DIFF
--- a/openvpn_server_management.sh
+++ b/openvpn_server_management.sh
@@ -1720,7 +1720,7 @@ renew_certificate() {
     
     # Use easyrsa renew command (available in easyrsa 3.2.1+)
     # If renew is not available, use the expire + sign-req method
-    if easyrsa help 2>&1 | grep -q "renew"; then
+    if easyrsa help 2>&1 | grep -q "\brenew\b"; then
         easyrsa renew "$cert_name" nopass
     else
         echo "Note: Using expire + sign-req method (easyrsa < 3.2.1)"


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
There is another 'revoke-renewed' command which passed the grep check so
it was trying to use 'easyrsa renew' on newer versions too.
<!-- === GH HISTORY FENCE === -->
